### PR TITLE
Add DELETE on RecommendationRequest Controller 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -74,4 +74,14 @@ public class RecommendationRequestController extends ApiController {
 
         return savedrecommendationrequest;
     }
+    @Operation(summary= "Get a single recommendation request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RecommendationRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        return recommendationRequest;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -74,6 +74,7 @@ public class RecommendationRequestController extends ApiController {
 
         return savedrecommendationrequest;
     }
+
     @Operation(summary= "Get a single recommendation request")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
@@ -83,5 +84,17 @@ public class RecommendationRequestController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
         return recommendationRequest;
+    }
+
+    @Operation(summary= "Delete a RecommendationRequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(recommendationRequest);
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,77 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "RecommendationRequests")
+@RequestMapping("/api/RecommendationRequest")
+@RestController
+@Slf4j
+public class RecommendationRequestController extends ApiController {
+
+    @Autowired
+    RecommendationRequestRepository recommendationRequestRepository;
+
+    @Operation(summary= "List all recommendation requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RecommendationRequest> allRecommendationRequests() {
+        Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
+        return requests;
+    }
+
+    @Operation(summary= "Create a new recommendation request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public RecommendationRequest postRecommendationRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="professorEmail") @RequestParam String professorEmail,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="dateRequested") @RequestParam("dateRequested") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateRequested,
+            @Parameter(name="dateNeeded") @RequestParam("dateNeeded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateNeeded,
+            @Parameter(name="done") @RequestParam boolean done)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateRequested={}", dateRequested);
+        log.info("dateNeeded={}", dateNeeded);
+
+        RecommendationRequest recommendationRequest = new RecommendationRequest();
+        recommendationRequest.setRequesterEmail(requesterEmail);
+        recommendationRequest.setProfessorEmail(professorEmail);
+        recommendationRequest.setExplanation(explanation);
+        recommendationRequest.setDateRequested(dateRequested);
+        recommendationRequest.setDateNeeded(dateNeeded);
+        recommendationRequest.setDone(done);
+
+        RecommendationRequest savedrecommendationrequest = recommendationRequestRepository.save(recommendationRequest);
+
+        return savedrecommendationrequest;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "recommendationrequest")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface RecommendationRequestRepository extends CrudRepository<RecommendationRequest, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequest-1",
+          "author": "EmilyT",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATIONREQUEST"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_1"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATIONREQUEST"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,152 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+        @MockBean
+        RecommendationRequestRepository recommendationRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/RecommendationRequest/all
+        
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/RecommendationRequest/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/RecommendationRequest/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_RecommendationRequest() throws Exception {
+
+                // arrange
+                LocalDateTime dreq1 = LocalDateTime.parse("2022-04-20T00:00:00");
+                LocalDateTime dneed1 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+                RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                                .requesterEmail("cgaucho@ucsb.edu")
+                                .professorEmail("phtcon@ucsb.edu")
+                                .explanation("BS/MS program")
+                                .dateRequested(dreq1)
+                                .dateNeeded(dneed1)
+                                .done(false)
+                                .build();
+
+                LocalDateTime dreq2 = LocalDateTime.parse("2022-05-20T00:00:00");
+                LocalDateTime dneed2 = LocalDateTime.parse("2022-11-15T00:00:00");
+
+                RecommendationRequest recommendationRequest2 = RecommendationRequest.builder()
+                                .requesterEmail("ldelplaya@ucsb.edu")
+                                .professorEmail("richert@ucsb.edu")
+                                .explanation("PhD CS Stanford")
+                                .dateRequested(dreq2)
+                                .dateNeeded(dneed2)
+                                .done(true)
+                                .build();
+
+                ArrayList<RecommendationRequest> expectedRequests = new ArrayList<>();
+                expectedRequests.addAll(Arrays.asList(recommendationRequest1, recommendationRequest2));
+
+                when(recommendationRequestRepository.findAll()).thenReturn(expectedRequests);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/RecommendationRequest/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequests);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/RecommendationRequest/post...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/RecommendationRequest/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/RecommendationRequest/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
+                // arrange
+
+                LocalDateTime dreq1 = LocalDateTime.parse("2022-04-20T00:00:00");
+                LocalDateTime dneed1 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+                RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                                .requesterEmail("cgaucho@ucsb.edu")
+                                .professorEmail("phtcon@ucsb.edu")
+                                .explanation("BS/MS program")
+                                .dateRequested(dreq1)
+                                .dateNeeded(dneed1)
+                                .done(true)
+                                .build();
+
+                when(recommendationRequestRepository.save(eq(recommendationRequest1))).thenReturn(recommendationRequest1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/RecommendationRequest/post?requesterEmail=cgaucho@ucsb.edu&professorEmail=phtcon@ucsb.edu&explanation=BS/MS program&dateRequested=2022-04-20T00:00:00&dateNeeded=2022-05-01T00:00:00&done=true")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).save(recommendationRequest1);
+                String expectedJson = mapper.writeValueAsString(recommendationRequest1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -149,4 +149,63 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+        
+        // Tests for GET /api/RecommendationRequest?id=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/RecommendationRequest?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime dreq1 = LocalDateTime.parse("2022-04-20T00:00:00");
+                LocalDateTime dneed1 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+                RecommendationRequest recommendationRequest = RecommendationRequest.builder()
+                                .requesterEmail("cgaucho@ucsb.edu")
+                                .professorEmail("phtcon@ucsb.edu")
+                                .explanation("BS/MS program")
+                                .dateRequested(dreq1)
+                                .dateNeeded(dneed1)
+                                .done(true)
+                                .build();
+
+                when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(recommendationRequest));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/RecommendationRequest?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(recommendationRequest);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/RecommendationRequest?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -208,4 +208,59 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                 assertEquals("EntityNotFoundException", json.get("type"));
                 assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
         }
+        
+        // Tests for DELETE /api/RecommendationRequest?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                LocalDateTime dreq1 = LocalDateTime.parse("2022-04-20T00:00:00");
+                LocalDateTime dneed1 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+                RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                                .requesterEmail("cgaucho@ucsb.edu")
+                                .professorEmail("phtcon@ucsb.edu")
+                                .explanation("BS/MS program")
+                                .dateRequested(dreq1)
+                                .dateNeeded(dneed1)
+                                .done(true)
+                                .build();
+
+                when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.of(recommendationRequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/RecommendationRequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(15L);
+                verify(recommendationRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 15 deleted", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_recommendationrequest_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/RecommendationRequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 15 not found", json.get("message"));
+        }
 }


### PR DESCRIPTION
In this PR, I added a DELETE on RecommendationRequest Controller that shows on the swagger ui, allowing you to delete a request from the database table.

Closes #24 