### PR TITLE
jm - created database files for help requests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private Boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+ 
+}

--- a/src/main/resources/db/migration/changes/HelpRequests.json
+++ b/src/main/resources/db/migration/changes/HelpRequests.json
@@ -2,8 +2,8 @@
   "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "UCSBDates-1",
-        "author": "MattP",
+        "id": "HelpRequests-1",
+        "author": "JeffreyM",
         "preConditions": [
           {
             "onFail": "MARK_RAN"
@@ -12,7 +12,7 @@
             "not": [
               {
                 "tableExists": {
-                  "tableName": "UCSBDATES"
+                  "tableName": "HELPREQUESTS"
                 }
               }
             ]
@@ -27,7 +27,7 @@
                     "autoIncrement": true,
                     "constraints": {
                       "primaryKey": true,
-                      "primaryKeyName": "CONSTRAINT_5"
+                      "primaryKeyName": "CONSTAINT_HELPREQUEST"
                     },
                     "name": "ID",
                     "type": "BIGINT"
@@ -35,24 +35,42 @@
                 },
                 {
                   "column": {
-                    "name": "LOCAL_DATE_TIME",
+                    "name": "REQUESTER_EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TEAM_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TABLE_OR_BREAKOUT_ROOM",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REQUEST_TIME",
                     "type": "TIMESTAMP"
                   }
                 },
                 {
                   "column": {
-                    "name": "NAME",
+                    "name": "EXPLANATION",
                     "type": "VARCHAR(255)"
                   }
                 },
                 {
                   "column": {
-                    "name": "QUARTERYYYYQ",
-                    "type": "VARCHAR(255)"
+                    "name": "SOLVED",
+                    "type": "BOOLEAN"
                   }
                 }
               ],
-              "tableName": "UCSBDATES"
+              "tableName": "HELPREQUESTS"
             }
           }
         ]

--- a/src/main/resources/db/migration/changes/HelpRequests.json
+++ b/src/main/resources/db/migration/changes/HelpRequests.json
@@ -27,7 +27,7 @@
                     "autoIncrement": true,
                     "constraints": {
                       "primaryKey": true,
-                      "primaryKeyName": "CONSTAINT_HELPREQUEST"
+                      "primaryKeyName": "CONSTRAINT_HELPREQUEST"
                     },
                     "name": "ID",
                     "type": "BIGINT"


### PR DESCRIPTION
Created the `@Entity`, `@Repsitory`, and database migration files for HelpRequests.
* Found in `HelpRequest.java`, `HelpRequestRepository.java`, and `HelpRequest.json`

`HelpRequest` database is shown in the H2_Console:
<img width="693" alt="image" src="https://github.com/ucsb-cs156-s24/team02-s24-4pm-8/assets/61306390/e9f65511-402a-49e5-abe8-b4eb622a006b">

Closes #32 